### PR TITLE
Reuse the DefaultContractResolver.

### DIFF
--- a/src/Faithlife.Json/JsonUtility.cs
+++ b/src/Faithlife.Json/JsonUtility.cs
@@ -358,14 +358,7 @@ namespace Faithlife.Json
 			JsonSerializerSettings serializerSettings =
 				new JsonSerializerSettings
 				{
-					ContractResolver = new DefaultContractResolver
-					{
-						NamingStrategy = new CamelCaseNamingStrategy
-						{
-							OverrideSpecifiedNames = false,
-							ProcessDictionaryKeys = false
-						}
-					},
+					ContractResolver = s_defaultContractResolver,
 					DateParseHandling = DateParseHandling.None,
 					NullValueHandling = settings?.IncludesNullValues ?? false ? NullValueHandling.Include : NullValueHandling.Ignore,
 					MissingMemberHandling = settings?.RejectsExtraProperties ?? false ? MissingMemberHandling.Error : MissingMemberHandling.Ignore,
@@ -396,6 +389,15 @@ namespace Faithlife.Json
 				value = new JValue((object) null);
 			return value;
 		}
+
+		private static readonly DefaultContractResolver s_defaultContractResolver = new DefaultContractResolver
+		{
+			NamingStrategy = new CamelCaseNamingStrategy
+			{
+				OverrideSpecifiedNames = false,
+				ProcessDictionaryKeys = false
+			}
+		};
 
 		private static readonly IReadOnlyList<JsonConverter> s_defaultConverters =
 			new JsonConverter[]

--- a/tests/Faithlife.Json.Tests/JsonUtilityTests.cs
+++ b/tests/Faithlife.Json.Tests/JsonUtilityTests.cs
@@ -122,6 +122,17 @@ namespace Faithlife.Json.Tests
 			Assert.AreEqual(JsonUtility.ToJson(hasNullableValue), @"{""value"":""hi""}");
 		}
 
+		[Test]
+		[MaxTime(1000)]
+		public void ToFromPerformance()
+		{
+			Widget widget = new Widget { Title = "title", Kind = new WidgetKind { WeightInGrams = 1.2, ReleaseDate = new DateTime(2010, 9, 8, 7, 6, 5, DateTimeKind.Utc) } };
+			for (int i = 0; i < 10000; i++)
+			{
+				JsonUtility.FromJson<Widget>(JsonUtility.ToJson(widget));
+			}
+		}
+
 		public class Widget
 		{
 			public string Title { get; set; }


### PR DESCRIPTION
Reusing the resolver reuses the contract cache, as recommended in the
Newtonsoft.Json docs.