### PR TITLE
Add ValueTypeDto with Converter and tests.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,10 @@ is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
+### 0.4.0
+
+* [minor] Add `ValueTypeDto<T>` and `ValueTypeDtoJsonConverter` and use by default with `JsonUtility`.
+
 ## Released
 
 ### 0.3.1

--- a/src/Faithlife.Json/Converters/ValueTypeDtoJsonConverter.cs
+++ b/src/Faithlife.Json/Converters/ValueTypeDtoJsonConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Faithlife.Utility;
+using Newtonsoft.Json;
+
+namespace Faithlife.Json.Converters
+{
+	/// <summary>
+	/// Supports JSON conversion of ValueTypeDto{T}.
+	/// </summary>
+	public class ValueTypeDtoJsonConverter : JsonConverter
+	{
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType.IsGenericType() && objectType.GetGenericTypeDefinition() == typeof(ValueTypeDto<>);
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			// make sure it has a value; instances without a value must be ignored
+			var valueTypeDto = (IValueTypeDto) value;
+			if (!valueTypeDto.HasValue)
+			{
+				string valueTypeName = valueTypeDto.GetType().GenericTypeArguments.Single().Name;
+				throw new InvalidOperationException(("ValueTypeDto<{0}>.HasValue is false. " +
+					"ValueTypeDto properties should include these attributes: " +
+						"[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Include), DefaultValueDefault(typeof(ValueTypeDto<{0}>))]")
+							.FormatInvariant(valueTypeName));
+			}
+
+			// serialize value
+			serializer.Serialize(writer, valueTypeDto.Value);
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			// get T of ValueTypeDto<T>
+			Type valueType = objectType.GenericTypeArguments.Single();
+
+			// deserialize using T
+			object value = serializer.Deserialize(reader, valueType);
+
+			// call ValueTypeDto<T>(T value) constructor
+			ConstructorInfo constructorInfo = GetConstructor(objectType, new[] { valueType });
+			Verify.IsNotNull(constructorInfo);
+			return constructorInfo.Invoke(new[] { value });
+		}
+
+		private static ConstructorInfo GetConstructor(Type type, Type[] types)
+			=> type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(x => x.IsPublic && EnumerableUtility.AreEqual(x.GetParameters().Select(p => p.ParameterType), types));
+	}
+}

--- a/src/Faithlife.Json/IValueTypeDto.cs
+++ b/src/Faithlife.Json/IValueTypeDto.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Faithlife.Json
+{
+	/// <summary>
+	/// Represents an value type for serialization/deserialization.
+	/// </summary>
+	public interface IValueTypeDto
+	{
+		/// <summary>
+		/// Gets a value indicating whether the current IValueTypeDto object has a value.
+		/// </summary>
+		bool HasValue { get; }
+
+		/// <summary>
+		/// Gets the value of the current IValueTypeDto value.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">The HasValue property is false.</exception>
+		object Value { get; }
+
+		/// <summary>
+		/// Gets the type of the value that can be stored by this IValueTypeDto instance.
+		/// </summary>
+		/// <value>The type of the value that can be stored by this IValueTypeDto instance.</value>
+		Type ValueType { get; }
+	}
+}

--- a/src/Faithlife.Json/JsonUtility.cs
+++ b/src/Faithlife.Json/JsonUtility.cs
@@ -406,6 +406,7 @@ namespace Faithlife.Json
 				new IsoDateTimeUtcJsonConverter(),
 				new IsoDateTimeOffsetJsonConverter(),
 				new OptionalJsonConverter(),
+				new ValueTypeDtoJsonConverter(),
 			};
 	}
 }

--- a/src/Faithlife.Json/ValueTypeDto.cs
+++ b/src/Faithlife.Json/ValueTypeDto.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using Faithlife.Json.Converters;
+using Faithlife.Utility;
+
+namespace Faithlife.Json
+{
+	/// <summary>
+	/// Wraps a value type for JSON serialzation/deserialzation in order to handle missing values.
+	/// When a value is not present in the JSON, a value type will normally be deserialized as the default value for that type.
+	/// This class instead deserializes with HasValue = false and will throw and an exception if Value is accessed (implicitly or explicitly).
+	/// Implicit casting allows usage of ValueTypeDto{T} just like <paramtyperef name="T"/>.
+	/// </summary>
+	/// <remarks>
+	/// Use <see cref="Optional{T}"/> for serializing/deserializing optional ValueType values.
+	/// Use <see cref="ValueTypeDto{T}"/> for serializing/deserializing required ValueType values.
+	/// Note that <see cref="ValueTypeDto{T}"/> also supports "fields" handling when a value is not requested and therefore not populated.
+	/// <see cref="ValueTypeDto{T}"/> should be used in conjunction with <see cref="ValueTypeDtoJsonConverter"/>.
+	/// Any property of this type should use the following attributes:
+	/// [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Include), DefaultValueDefault(typeof(ValueTypeDto&lt;bool&gt;))]
+	/// </remarks>
+	/// <example>
+	/// * `{"MyBoolean":true}` -> true
+	/// * `{"MyBoolean":false}` -> false
+	/// * `{"MyBoolean":null}` -> Exception during deserialization (null does not deserialize to a boolean)
+	/// * `{}` -> HasValue == false; exception if Value is accessed.
+	/// </example>
+	/// <typeparam name="T">The type of the value type.</typeparam>
+	public struct ValueTypeDto<T> : IEquatable<ValueTypeDto<T>>, IValueTypeDto
+		where T : struct
+	{
+		/// <summary>
+		/// Initializes a new instance of the ValueTypeDto{T} structure to the specified value. 
+		/// </summary>
+		/// <param name="value">The value.</param>
+		public ValueTypeDto(T value)
+		{
+			m_value = value;
+			m_hasValue = true;
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether the current ValueTypeDto{T} object has a value.
+		/// </summary>
+		public bool HasValue => m_hasValue;
+
+		/// <summary>
+		/// Gets the value of the current ValueTypeDto{T} value.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">The HasValue property is false.</exception>
+		public T Value
+		{
+			get
+			{
+				if (!m_hasValue)
+					throw new InvalidOperationException("The HasValue property is false.");
+
+				return m_value;
+			}
+		}
+
+		/// <summary>
+		/// Gets the value of the current ValueTypeDto{T} value.
+		/// </summary>
+		/// <exception cref="InvalidOperationException">The HasValue property is false.</exception>
+		object IValueTypeDto.Value => Value;
+
+		/// <summary>
+		/// Gets the type of the value that can be stored by this IValueTypeDto instance.
+		/// </summary>
+		/// <value>The type of the value that can be stored by this IValueTypeDto instance.</value>
+		Type IValueTypeDto.ValueType => typeof(T);
+
+		/// <summary>
+		/// Indicates whether the current object is equal to another object of the same type.
+		/// </summary>
+		/// <param name="other">An object to compare with this object.</param>
+		/// <returns>True if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.</returns>
+		public bool Equals(ValueTypeDto<T> other) => m_hasValue && other.m_hasValue ? EqualityComparer<T>.Default.Equals(m_value, other.m_value) : m_hasValue == other.m_hasValue;
+
+		/// <summary>
+		/// Indicates whether the current object is equal to another object of the same type.
+		/// </summary>
+		/// <param name="obj">An object to compare with this object.</param>
+		/// <returns>True if the current object is equal to the <paramref name="obj"/> parameter; otherwise, false.</returns>
+		public override bool Equals(object obj) => obj is ValueTypeDto<T> valueTypeDto && Equals(valueTypeDto);
+
+		/// <summary>
+		/// Retrieves the hash code of the object returned by the Value property.
+		/// </summary>
+		/// <returns>The hash code of the object returned by the Value property if the HasValue property is true; otherwise zero.</returns>
+		public override int GetHashCode() => m_hasValue ? EqualityComparer<T>.Default.GetHashCode(m_value) : 0;
+
+		/// <summary>
+		/// Retrieves the value of the current ValueTypeDto{T} object, or the object's default value.
+		/// </summary>
+		/// <returns>The value of the Value property if the HasValue property is true; otherwise, the default value of the type T.</returns>
+		public T GetValueOrDefault() => GetValueOrDefault(default);
+
+		/// <summary>
+		/// Retrieves the value of the current ValueTypeDto{T} object, or the specified default value.
+		/// </summary>
+		/// <param name="defaultValue">A value to return if the HasValue property is false.</param>
+		/// <returns>The value of the Value property if the HasValue property is true; otherwise, the defaultValue parameter.</returns>
+		public T GetValueOrDefault(T defaultValue) => m_hasValue ? m_value : defaultValue;
+
+		/// <summary>
+		/// Returns the text representation of the value of the current ValueTypeDto{T} object.
+		/// </summary>
+		/// <returns>The text representation of the object returned by the Value property if the HasValue property is true and the Value is not null; otherwise the empty string.</returns>
+		public override string ToString() => m_hasValue ? m_value.ToString() : "";
+
+		/// <summary>
+		/// Creates a new ValueTypeDto{T} object initialized to a specified value. 
+		/// </summary>
+		/// <param name="value">A value type.</param>
+		/// <returns>An ValueTypeDto{T} object whose Value property is initialized with the value parameter.</returns>
+		public static implicit operator ValueTypeDto<T>(T value) => new ValueTypeDto<T>(value);
+
+		/// <summary>
+		/// Returns the value of a specified ValueTypeDto{T} value.
+		/// </summary>
+		/// <param name="valueTypeDto">An ValueTypeDto{T} value.</param>
+		/// <returns>The value of the Value property for the value parameter.</returns>
+		/// <exception cref="InvalidOperationException">The HasValue property is false.</exception>
+		public static implicit operator T(ValueTypeDto<T> valueTypeDto) => valueTypeDto.Value;
+
+		/// <summary>
+		/// Compares two instances for equality.
+		/// </summary>
+		/// <param name="left">The left instance.</param>
+		/// <param name="right">The right instance.</param>
+		/// <returns><c>true</c> the instances are equal; otherwise, <c>false</c>.</returns>
+		public static bool operator ==(ValueTypeDto<T> left, ValueTypeDto<T> right) => left.Equals(right);
+
+		/// <summary>
+		/// Compares two instances for inequality.
+		/// </summary>
+		/// <param name="left">The left instance.</param>
+		/// <param name="right">The right instance.</param>
+		/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
+		public static bool operator !=(ValueTypeDto<T> left, ValueTypeDto<T> right) => !left.Equals(right);
+
+		readonly bool m_hasValue;
+		readonly T m_value;
+	}
+}

--- a/tests/Faithlife.Json.Tests/ValueTypeDtoJsonConverterTests.cs
+++ b/tests/Faithlife.Json.Tests/ValueTypeDtoJsonConverterTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Faithlife.Json.Converters;
+using NUnit.Framework;
+using Newtonsoft.Json;
+
+namespace Faithlife.Json.Tests
+{
+	[TestFixture]
+	public class ValueTypeDtoJsonConverterTests
+	{
+		[Test]
+		public void ThrowsWhenNoValue()
+		{
+			Assert.Throws<InvalidOperationException>(() => { bool _ = new ValueTypeDto<bool>().Value; });
+			Assert.Throws<InvalidOperationException>(() => { bool _ = new ValueTypeDto<bool>(); });
+			Assert.Throws<InvalidOperationException>(() => { bool _ = default(ValueTypeDto<bool>).Value; });
+			Assert.Throws<InvalidOperationException>(() => { bool _ = default(ValueTypeDto<bool>); });
+		}
+
+		[Test]
+		public void ImplicitCastSuccess()
+		{
+			Assert.IsTrue(new ValueTypeDto<bool>(true).Value);
+			Assert.IsTrue(new ValueTypeDto<bool>(true));
+
+			var valueTypeDtoTest = new ValueTypeDtoTest { MyBoolean = true };
+			bool myBoolean = valueTypeDtoTest.MyBoolean;
+			Assert.IsTrue(myBoolean);
+		}
+
+		[TestCase(@"{""MyBoolean"":null}")]
+		public void DeserializeFailureOnNullValueType(string json)
+		{
+			AssertDeserializationFailure<ValueTypeDtoTest>(json);
+		}
+
+		[TestCase(@"{""MyBoolean"":true}", true, true)]
+		[TestCase(@"{""MyBoolean"":false}", true, false)]
+		[TestCase(@"{}", false, null)]
+		public void DeserializeSuccess(string json, bool expectedHasValue, bool? expectedValue)
+		{
+			var expectedValueTypeDto = !expectedHasValue
+				? new ValueTypeDto<bool>()
+				: new ValueTypeDto<bool>(expectedValue ?? throw new InvalidOperationException($"Invalid test case: \"{nameof(expectedValue)}\" may not be null when {nameof(expectedHasValue)} is true."));
+
+			AssertDeserializationSuccess(json, new ValueTypeDtoTest { MyBoolean = expectedValueTypeDto });
+		}
+
+		[TestCase(false, null)]
+		[TestCase(null, null)]
+		public void SerializeFailureOnMissingAttributes(bool? hasValue, bool? value)
+		{
+			var valueTypeDtoTest = new ValueTypeDtoNoAttributesTest();
+			if (hasValue.HasValue)
+			{
+				valueTypeDtoTest.MyBoolean = !hasValue.Value
+					? new ValueTypeDto<bool>()
+					: new ValueTypeDto<bool>(value ?? throw new InvalidOperationException($"Invalid test case: \"{nameof(value)}\" may not be null when {nameof(hasValue)} is true."));
+			}
+
+			AssertSerializationFailure(valueTypeDtoTest);
+		}
+
+		[TestCase(true, true, @"{""MyBoolean"":true}")]
+		[TestCase(true, false, @"{""MyBoolean"":false}")]
+		[TestCase(false, null, @"{}")]
+		[TestCase(null, null, @"{}")]
+		public void SerializeSuccess(bool? hasValue, bool? value, string expectedJson)
+		{
+			var valueTypeDtoTest = new ValueTypeDtoTest();
+			if (hasValue.HasValue)
+			{
+				valueTypeDtoTest.MyBoolean = !hasValue.Value
+					? new ValueTypeDto<bool>()
+					: new ValueTypeDto<bool>(value ?? throw new InvalidOperationException($"Invalid test case: \"{nameof(value)}\" may not be null when {nameof(hasValue)} is true."));
+			}
+
+			AssertSerializationSuccess(valueTypeDtoTest, expectedJson);
+		}
+
+		public struct ValueTypeDtoTest
+		{
+			[JsonProperty("MyBoolean", DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Include), DefaultValueDefault(typeof(ValueTypeDto<bool>))]
+			public ValueTypeDto<bool> MyBoolean { get; set; }
+		}
+
+		public struct ValueTypeDtoNoAttributesTest
+		{
+			[JsonProperty("MyBoolean")]
+			public ValueTypeDto<bool> MyBoolean { get; set; }
+		}
+
+		private static void AssertDeserializationFailure<T>(string json)
+		{
+			Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<T>(json, new ValueTypeDtoJsonConverter()));
+			Assert.Throws<JsonSerializationException>(() => JsonUtility.FromJson<T>(json));
+		}
+
+		private static void AssertDeserializationSuccess<T>(string json, T expectedValue)
+		{
+			Assert.AreEqual(expectedValue, JsonConvert.DeserializeObject<T>(json, new ValueTypeDtoJsonConverter()), $"Failed: {json}");
+			Assert.AreEqual(expectedValue, JsonUtility.FromJson<T>(json), $"Failed: {json}");
+		}
+
+		private static void AssertSerializationFailure<T>(T test)
+		{
+			Assert.Throws<InvalidOperationException>(() => JsonConvert.SerializeObject(test, new ValueTypeDtoJsonConverter()));
+			Assert.Throws<InvalidOperationException>(() => JsonUtility.ToJson(test));
+		}
+
+		private static void AssertSerializationSuccess<T>(T value, string expectedJson)
+		{
+			Assert.AreEqual(expectedJson, JsonConvert.SerializeObject(value, new ValueTypeDtoJsonConverter()), $"Failed: {expectedJson}");
+			Assert.AreEqual(expectedJson, JsonUtility.ToJson(value), $"Failed: {expectedJson}");
+		}
+	}
+}


### PR DESCRIPTION
`ValueTypeDto<T>` is a wrapper around value types to solve some of the issues with mapping value types to a C# object.  It is similar to `Optional<T>` except that it is only used for value types and it uses an implicit cast from `ValueTypeDto<T>` to `T` instead of an explicit one.

The following examples demonstrate why it is beneficial.

*Naive approach*:
```
public class Foo
{
	public bool IsOn { get; set; }
	public int? NumberOfWidgets { get; set; }
	public string Name { get; set; }
}

// usage
bool isOn = myFoo.IsOn;
int? numberOfWidgets = myFoo.NumberOfWidgets;
```

In the naive approach, if `fields` passed to an API include `fields=foo.name` then no value will be passed in the JSON for `IsOn`.  This results in the default value for `bool` being assigned.  If a developer forgets that this field wasn't requested and accesses it then he will get incorrect data (`IsOn == false`) without any runtime errors.

*Technically-Correct-But-Misleading approach*:
```
public class Foo
{
	public bool? IsOn { get; set; }
	public int? NumberOfWidgets { get; set; }
	public string Name { get; set; }
}

// client-side usage
bool isOn = myFoo.IsOn ?? throw new InvalidOperationException($"\"{nameof(Foo.IsOn)}\" should never be null.");
int? numberOfWidgets = myFoo.NumberOfWidgets;

// server-side usage
if (!myFoo.IsOn.HasValue)
	throw new BadRequestException($"\"{nameof(IsOn)}\" is required.");
bool isOn = myFoo.IsOn.Value;
```

In the technically correct but misleading approach, value types are required to always be nullable.  This solves the problem of accidentally acting on a default value; instead the consumer of the DTO should throw an exception if the value is ever `null` (as in the example usage above).  However, note that `numberOfWidgets` is an `int?` in both the naive approach and this technically correct but misleading approach.  It is now impossible to determine from the C# client if `null` is an _expected_ value or only an _error_ value.  The only way to determine this is to look at documentation somewhere else (if it is correct) or the API source code.  This often results in consumers of API clients thinking that `null` values are expected, and if not it results in lots of manual exception throwing.

*ValueTypeDto<T> approach*:
```
public class Foo
{
	public ValueTypeDto<bool> IsOn { get; set; }
	public int? NumberOfWidgets { get; set; }
	public string Name { get; set; }
}

// client-side usage
bool isOn = myFoo.IsOn; // this will throw an exception if `IsOn` was not present in the JSON
int? numberOfWidgets = myFoo.NumberOfWidgets;

// server-side usage
if (!myFoo.IsOn.HasValue)
	throw new BadRequestException($"\"{nameof(IsOn)}\" is required.");
bool isOn = myFoo.IsOn;
```

In the `ValueTypeDto<T>` approach, usage is exactly the same as the naive approach (easy to use thanks to an implicit cast), however now an exception is thrown if accessing a value that wasn't present in the JSON.  There is a distinction between `ValueTypeDto<T>` and `T?` (e.g. now the C# DTO communicates the intent that `IsOn` should never be `null`) and thus it is not misleading.
